### PR TITLE
Fix bugs in inspections display

### DIFF
--- a/hextant-core/src/main/kotlin/hextant/base/EditorControl.kt
+++ b/hextant-core/src/main/kotlin/hextant/base/EditorControl.kt
@@ -288,7 +288,9 @@ abstract class EditorControl<R : Node>(
                     ev.consume()
                 }
             }
-            on(INSPECTIONS, consume = false) { showInspections() }
+            on(INSPECTIONS, consume = false) { ev ->
+                if (showInspections()) ev.consume()
+            }
         }
     }
 
@@ -310,18 +312,22 @@ abstract class EditorControl<R : Node>(
         return inspectionPopup.isShowing
     }
 
+    private fun addStyleCls(name: String) {
+        if (name !in styleClass) styleClass.add(name)
+    }
+
     private fun handleProblem(error: Boolean, warn: Boolean) {
         when {
             error -> {
-                styleClass.add("error")
-                styleClass.remove("warn")
+                addStyleCls("error")
+                styleClass.remove("warning")
             }
             warn  -> {
-                styleClass.add("warn")
+                addStyleCls("warning")
                 styleClass.remove("error")
             }
             else  -> {
-                styleClass.remove("warn")
+                styleClass.remove("warning")
                 styleClass.remove("error")
             }
         }

--- a/hextant-core/src/main/resources/hextant/core/style.css
+++ b/hextant-core/src/main/resources/hextant/core/style.css
@@ -189,12 +189,12 @@
     -fx-text-fill: green;
 }
 
-.error * {
+.error .hextant-text {
     -fx-text-fill: red !important;
 }
 
-.warn * {
-    -fx-text-fill: yellow !important;
+.warning .hextant-text {
+    -fx-text-fill: yellow;
 }
 
 .tree-cell {

--- a/hextant-expr/src/test/kotlin/hextant/expr/ExprEditorViewTest.kt
+++ b/hextant-expr/src/test/kotlin/hextant/expr/ExprEditorViewTest.kt
@@ -19,6 +19,7 @@ import hextant.fx.applyInputMethod
 import hextant.fx.registerShortcuts
 import hextant.impl.SelectionDistributor
 import hextant.inspect.Inspections
+import hextant.inspect.Severity.Error
 import hextant.inspect.Severity.Warning
 import hextant.inspect.of
 import hextant.main.HextantApplication
@@ -159,8 +160,7 @@ class ExprEditorViewTest : HextantApplication() {
         val inspections = context[Inspections]
         inspections.of<OperatorApplicationEditor>().registerInspection {
             description = "Prevent identical operations"
-            severity(Warning)
-            location(inspected.operand2)
+            severity(Error)
             val isPlus = inspected.operator.result.map { it.orNull() == Plus }
             val operandIs0 =
                 inspected.operand2.result.map { it.orNull() is IntLiteral && it.force().value == 0 }


### PR DESCRIPTION
- add error/warning style classes only once
- give errors a higher priority than warnings