### PR TITLE
Fix #24

### DIFF
--- a/hextant-core/src/main/kotlin/hextant/base/EditorControl.kt
+++ b/hextant-core/src/main/kotlin/hextant/base/EditorControl.kt
@@ -12,6 +12,7 @@ import hextant.fx.*
 import hextant.fx.ModifierValue.DOWN
 import hextant.impl.*
 import hextant.inspect.Inspections
+import hextant.inspect.gui.InspectionPopup
 import hextant.undo.UndoManager
 import javafx.geometry.Side
 import javafx.scene.Node
@@ -42,10 +43,10 @@ abstract class EditorControl<R : Node>(
 
     private val inspections = context[Inspections]
 
-    //    private val inspectionPopup = run {
-    //        val inspections = this.inspections //Prevent capturing of this
-    //        InspectionPopup(context) { inspections.getProblems(target) }
-    //    }
+    private val inspectionPopup = run {
+        val inspections = this.inspections //Prevent capturing of this
+        InspectionPopup(context) { inspections.getProblems(target) }
+    }
 
     private val hasError = inspections.hasError(target)
 
@@ -326,9 +327,8 @@ abstract class EditorControl<R : Node>(
     }
 
     private fun showInspections(): Boolean {
-        //        inspectionPopup.show(this)
-        //        return inspectionPopup.isShowing
-        return false
+        inspectionPopup.show(this)
+        return inspectionPopup.isShowing
     }
 
     private fun addStyleCls(name: String) {

--- a/hextant-core/src/main/kotlin/hextant/completion/gui/CompletionPopup.kt
+++ b/hextant-core/src/main/kotlin/hextant/completion/gui/CompletionPopup.kt
@@ -5,6 +5,7 @@
 package hextant.completion.gui
 
 import hextant.completion.Completion
+import hextant.fx.registerShortcuts
 import javafx.scene.input.KeyCode.ENTER
 import javafx.scene.layout.VBox
 import javafx.stage.Popup
@@ -16,6 +17,11 @@ class CompletionPopup<C> : Popup() {
 
     init {
         isAutoHide = true
+        scene.registerShortcuts {
+            on("ESCAPE") {
+                hide()
+            }
+        }
     }
 
     fun setCompletions(completions: Collection<Completion<C>>) {
@@ -44,8 +50,7 @@ class CompletionPopup<C> : Popup() {
 
     private fun choose(c: Completion<C>) {
         choose.fire(c)
-        ownerNode.requestFocus()
+        hide()
     }
-
 }
 

--- a/hextant-core/src/main/kotlin/hextant/core/view/AbstractTokenEditorControl.kt
+++ b/hextant-core/src/main/kotlin/hextant/core/view/AbstractTokenEditorControl.kt
@@ -63,7 +63,10 @@ open class AbstractTokenEditorControl(
 
     private val completionHelper = CompleterPopupHelper(completer, this.textField::getText)
 
-    private val obs = completionHelper.completionChosen.subscribe(this) { _, c -> editor.setText(c.completed) }
+    private val obs = completionHelper.completionChosen.subscribe(this) { _, c ->
+        editor.setText(c.completed)
+        scene.focusNext()
+    }
 
     final override fun createDefaultRoot() = textField
 

--- a/hextant-core/src/main/kotlin/hextant/fx/scene.kt
+++ b/hextant-core/src/main/kotlin/hextant/fx/scene.kt
@@ -83,26 +83,34 @@ private fun Scene.listenForShift() {
     }
 }
 
-fun Scene.traverseOnArrowWithCtrl() {
+internal fun Scene.traverseOnArrowWithCtrl() {
     addEventHandler(KeyEvent.KEY_RELEASED) { ev ->
         if (ev.code == KeyCode.LEFT) {
-            val prev = getFocusedEditorControl()?.previous ?: return@addEventHandler
-            val lastChild = generateSequence(prev) {
-                if (it is FXExpanderView) it.root as? EditorControl<*>
-                else it.editorChildren().lastOrNull()
-            }.last()
-            ev.consume()
-            lastChild.focus()
+            if (focusPrevious()) ev.consume()
         } else if (ev.code == KeyCode.RIGHT) {
-            val next = getFocusedEditorControl()?.next ?: return@addEventHandler
-            val firstChild = generateSequence(next) {
-                if (it is FXExpanderView) it.root as? EditorControl<*>
-                else it.editorChildren().firstOrNull()
-            }.last()
-            ev.consume()
-            firstChild.focus()
+            if (focusNext()) ev.consume()
         }
     }
+}
+
+internal fun Scene.focusNext(): Boolean {
+    val next = getFocusedEditorControl()?.next ?: return false
+    val firstChild = generateSequence(next) {
+        if (it is FXExpanderView) it.root as? EditorControl<*>
+        else it.editorChildren().firstOrNull()
+    }.last()
+    firstChild.focus()
+    return true
+}
+
+internal fun Scene.focusPrevious(): Boolean {
+    val prev = getFocusedEditorControl()?.previous ?: return false
+    val lastChild = generateSequence(prev) {
+        if (it is FXExpanderView) it.root as? EditorControl<*>
+        else it.editorChildren().lastOrNull()
+    }.last()
+    lastChild.focus()
+    return true
 }
 
 private fun Scene.getFocusedEditorControl(): EditorControl<*>? {

--- a/hextant-core/src/main/kotlin/hextant/inspect/gui/InspectionPopup.kt
+++ b/hextant-core/src/main/kotlin/hextant/inspect/gui/InspectionPopup.kt
@@ -6,6 +6,7 @@ package hextant.inspect.gui
 
 import hextant.Context
 import hextant.fx.registerShortcut
+import hextant.fx.registerShortcuts
 import hextant.get
 import hextant.impl.Stylesheets
 import hextant.inspect.Problem
@@ -27,7 +28,12 @@ class InspectionPopup(private val context: Context, problems: () -> Set<Problem>
         context[Stylesheets].apply(scene)
         container.styleClass.add("problem-list")
         setOnShowing { update() }
-        setOnHidden { ownerNode.requestFocus() }
+        isAutoHide = true
+        scene.registerShortcuts {
+            on("ESCAPE") {
+                hide()
+            }
+        }
         scene.root = container
     }
 

--- a/hextant-expr/src/test/kotlin/hextant/expr/ExprEditorViewTest.kt
+++ b/hextant-expr/src/test/kotlin/hextant/expr/ExprEditorViewTest.kt
@@ -189,6 +189,12 @@ class ExprEditorViewTest : HextantApplication() {
                     inspected.setText("1")
                 }
             }
+            addFix {
+                description = "Set to '2'"
+                fixingBy {
+                    inspected.setText("2")
+                }
+            }
         }
         commands.of<ExprEditor<*>>().register<ExprEditor<*>, Unit> {
             description =


### PR DESCRIPTION
- hide completion popup and inspection popup on ESCAPE
- make inspection popup auto hide
- focus next when completion chosen in token editor